### PR TITLE
Implemented ability to return the NSTask's terminationStatus

### DIFF
--- a/GCDTask.h
+++ b/GCDTask.h
@@ -35,7 +35,7 @@
 - (void) launchWithOutputBlock: (void (^)(NSData* stdOutData)) stdOut
                 andErrorBlock: (void (^)(NSData* stdErrData)) stdErr
                      onLaunch: (void (^)()) launched
-                       onExit: (void (^)()) exit;
+                       onExit: (void (^)(int)) exit;
 
 - (BOOL) WriteStringToStandardInput: (NSString*) input;
 - (BOOL) WriteDataToStandardInput: (NSData*) input;

--- a/GCDTask.m
+++ b/GCDTask.m
@@ -18,7 +18,7 @@
 - (void) launchWithOutputBlock: (void (^)(NSData* stdOutData)) stdOut
                  andErrorBlock: (void (^)(NSData* stdErrData)) stdErr
                       onLaunch: (void (^)()) launched
-                        onExit: (void (^)()) exit
+                        onExit: (void (^)(int)) exit
 {
     executingTask = [[NSTask alloc] init];
  
@@ -106,7 +106,7 @@
             dispatch_source_cancel(_stdoutSource);
             dispatch_async(dispatch_get_main_queue(), ^{
                 if(exit)
-                    exit();
+                    exit([executingTask terminationStatus]);
             });
         }
 
@@ -153,7 +153,7 @@
         dispatch_source_cancel(_stdoutSource);
         dispatch_source_cancel(_stderrSource);
         if(exit)
-            exit();
+            exit([executingTask terminationStatus]);
     };
 
     [executingTask launch];


### PR DESCRIPTION
Sometimes it's helpful to be able to obtain the terminationStatus of the underlying NSTask.  This provides for that...but be aware that it alters the API slightly in that it requires an integer parameter for the onExit block.